### PR TITLE
Dockerfile: Update to ruby2.7 as necessary for current Tumbleweed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM opensuse/tumbleweed
 
 RUN zypper  --non-interactive --quiet ref \
- && zypper -n in osc ruby2.6 ruby2.6-devel git gcc make autoconf zlib-devel libxml2-devel libxslt-devel
+ && zypper -n in osc ruby2.7 ruby2.7-devel git gcc make autoconf zlib-devel libxml2-devel libxslt-devel
 RUN gem install bundler
-RUN bundle.ruby2.6 config build.nokogiri --use-system-libraries
+RUN bundle.ruby2.7 config build.nokogiri --use-system-libraries
 COPY .  /home/puller/pull_request_package
-RUN cd /home/puller/pull_request_package && bundler.ruby2.6 install
+RUN cd /home/puller/pull_request_package && bundler.ruby2.7 install
 
 RUN useradd -ms /bin/bash puller
 


### PR DESCRIPTION
In before I could build the container image but when trying to run I get

```
Traceback (most recent call last):
	8: from /home/puller/pull_request_package/runner.rb:5:in `<main>'
	7: from /usr/lib64/ruby/2.7.0/bundler.rb:174:in `require'
	6: from /usr/lib64/ruby/2.7.0/bundler.rb:151:in `setup'
	5: from /usr/lib64/ruby/2.7.0/bundler/runtime.rb:20:in `setup'
	4: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:237:in `specs_for'
	3: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:170:in `specs'
	2: from /usr/lib64/ruby/2.7.0/bundler/spec_set.rb:80:in `materialize'
	1: from /usr/lib64/ruby/2.7.0/bundler/spec_set.rb:80:in `map!'
/usr/lib64/ruby/2.7.0/bundler/spec_set.rb:86:in `block in materialize': Could not find abstract_method-1.2.1 in any of the sources (Bundler::GemNotFound)
```

now I got

```
STEP 6: RUN cd /home/puller/pull_request_package && bundler.ruby2.7 install
Traceback (most recent call last):
	2: from /usr/bin/bundler.ruby2.7:23:in `<main>'
	1: from /usr/lib64/ruby/2.7.0/rubygems.rb:294:in `activate_bin_path'
/usr/lib64/ruby/2.7.0/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /home/puller/pull_request_package/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3`
Error: error building at STEP "RUN cd /home/puller/pull_request_package && bundler.ruby2.7 install": error while running runtime: exit status 1
```

I do not have enough experience with ruby so I guess Gemfile.lock needs to be updated somehow as well.

If I delete `Gemfile.lock` I get to

```
STEP 15: COMMIT okurz/pull_request_package
02f3092dbb5ef7e9161f0b29c32c9b7dd7cbc89900f84f757a7e75db5d594726
02f3092dbb5ef7e9161f0b29c32c9b7dd7cbc89900f84f757a7e75db5d594726
Traceback (most recent call last):
	19: from /home/puller/pull_request_package/runner.rb:5:in `<main>'
	18: from /usr/lib64/ruby/2.7.0/bundler.rb:174:in `require'
	17: from /usr/lib64/ruby/2.7.0/bundler.rb:151:in `setup'
	16: from /usr/lib64/ruby/2.7.0/bundler/runtime.rb:20:in `setup'
	15: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:237:in `specs_for'
	14: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:170:in `specs'
	13: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:247:in `resolve'
	12: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:750:in `converge_locked_specs'
	11: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:750:in `each'
	10: from /usr/lib64/ruby/2.7.0/bundler/definition.rb:764:in `block in converge_locked_specs'
	 9: from /usr/lib64/ruby/2.7.0/bundler/source/git.rb:168:in `specs'
	 8: from /usr/lib64/ruby/2.7.0/bundler/source/path.rb:105:in `local_specs'
	 7: from /usr/lib64/ruby/2.7.0/bundler/source/git.rb:201:in `load_spec_files'
	 6: from /usr/lib64/ruby/2.7.0/bundler/source/path.rb:168:in `load_spec_files'
	 5: from /usr/lib64/ruby/2.7.0/bundler/source/path.rb:131:in `expanded_path'
	 4: from /usr/lib64/ruby/2.7.0/bundler/source/git.rb:93:in `install_path'
	 3: from /usr/lib64/ruby/2.7.0/bundler/source/git.rb:226:in `revision'
	 2: from /usr/lib64/ruby/2.7.0/bundler/source/git/git_proxy.rb:68:in `revision'
	 1: from /usr/lib64/ruby/2.7.0/bundler/source/git/git_proxy.rb:198:in `find_local_revision'
/usr/lib64/ruby/2.7.0/bundler/source/git/git_proxy.rb:241:in `allowed_in_path': The git source https://github.com/vpereira/pull_request_builder is not yet checked out. Please run `bundle install` before trying to start your application (Bundler::GitError)
```
